### PR TITLE
remove soucemaps from npm installs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,7 @@ tslint.json
 tsconfig.json
 index.ts
 lib
+dist/**/*.js.map
 
 .gitignore
 


### PR DESCRIPTION
fix a prob w/ webpack as sourcemaps look for `../lib/*` which is npm ignored.