### PR TITLE
Fix disabled localstorage

### DIFF
--- a/lib/helpers/webStorage.ts
+++ b/lib/helpers/webStorage.ts
@@ -86,17 +86,18 @@ export class WebStorageHelper {
 		if(typeof this.storageAvailability[sType] === 'boolean')
 			return this.storageAvailability[sType];
 
-		let isAvailable = true, storage = this.getWStorage(sType);
+		let isAvailable = true;
 
-		if(typeof storage === 'object') {
-			try {
-				storage.setItem('test-storage', 'foobar');
-				storage.removeItem('test-storage');
-			} catch(e) {
+		try {
+			var storage = this.getWStorage(sType);
+			if (typeof storage === 'object') {
 				isAvailable = false;
 			}
+			storage.setItem('test-storage', 'foobar');
+			storage.removeItem('test-storage');
+		} catch(e) {
+			isAvailable = false;
 		}
-		else isAvailable = false;
 
 		if(!isAvailable) console.warn(`${STORAGE_NAMES[sType]} storage unavailable, Ng2Webstorage will use a fallback strategy instead`);
 		return this.storageAvailability[sType] = isAvailable;


### PR DESCRIPTION
The function `getWStorage() `will crash if localstorage is disabled in browser. In Chrome, you can do it by setting "_Block sites from setting any data_" to true in your _Content settings_. 

The fix will move this function inside try-catch block so that the storage will return as unavailable if user has disabled localstorage in browser's settings.