### PR TITLE
Typo fix in getStorage function when using mockstorage

### DIFF
--- a/lib/helpers/webStorage.ts
+++ b/lib/helpers/webStorage.ts
@@ -66,7 +66,8 @@ export class WebStorageHelper {
 	static getStorage(sType:STORAGE):IWebStorage {
 		if(this.isStorageAvailable(sType))
 			return this.getWStorage(sType);
-		else MockStorageHelper.getStorage(sType);
+		else
+			return MockStorageHelper.getStorage(sType);
 	}
 
 	static getWStorage(sType:STORAGE):IWebStorage {


### PR DESCRIPTION
Hey again! 

This PR will fix a typo that was accidentally slipped in this commit: [4b7e77c
](https://github.com/PillowPillow/ng2-webstorage/commit/4b7e77c6188ec77f919b16549faf4f05ccd3987e)

I noticed this when I was testing the mockstorage when localstorage is disabled in the browser.

The ng2-webstorage library was not working because getStorage function was not returning anything :) Now it returns the Mockstorage if real storage is not available.
