### PR TITLE
Fix "storage" event handler for clear events.

### DIFF
--- a/lib/app.ts
+++ b/lib/app.ts
@@ -52,7 +52,12 @@ export class Ng2Webstorage {
 		if(typeof window !== 'undefined') {
 			window.addEventListener('storage', (event:StorageEvent) => this.ngZone.run(() => {
 				let storage:STORAGE = window.sessionStorage === event.storageArea ? STORAGE.session : STORAGE.local;
-				WebStorageHelper.refresh(storage, event.key);
+				if (event.key == null) {
+					WebStorageHelper.clearAll(storage);
+				}
+				else {
+					WebStorageHelper.refresh(storage, event.key);
+				}
 			}));
 		}
 	}


### PR DESCRIPTION
Fixes #58.

This handles session clear events according to the spec as provided on
the MDN website here:
https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent#Attributes

When a clear event is fired, all cached values for the given storage are
evicted.

This also resolves a NPE that would occur when a clear event was fired
from attempting to determine if the triggering key (null) matched the
managed-key pattern.