### PR TITLE
Adding peer dependency to @angular/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "webpack-merge": "^0.13.0",
     "zone.js": "^0.7.4"
   },
+  "peerDependencies": {
+    "@angular/core": "^4.0.1"
+  },
   "scripts": {
     "ngc": "ngc --p config/tsconfig.dist.json",
     "postngc": "node node_modules/rimraf/bin lib/**/app.ngfactory.* lib/**/*.ngsummary.json",


### PR DESCRIPTION
Hi,

I have complicated project's structure which uses many npm links between its parts. To maintain one version of angular through all modules, a custom webpack plugin reads package.json and if it sees peerDependency then it links it to most parent module. This approach failed in case of this package. 

I'm adding the peerDependency since it's unusual to require() something unlisted in dependencies or peerDependencies list. It won't harm anything.