### PR TITLE
Added config decorator to ensure, that configuration will be applied before first decorator will be executed.

### DIFF
--- a/example/modules/app/components/app.ts
+++ b/example/modules/app/components/app.ts
@@ -1,4 +1,11 @@
 import {Component} from '@angular/core';
+import {WebStorageConfig} from '../../../libwrapper';
+
+@WebStorageConfig({
+	separator: '.',
+	prefix: 'foobar',
+	caseSensitive: true
+})
 
 @Component({
 	selector: 'app',

--- a/lib/decorators/index.ts
+++ b/lib/decorators/index.ts
@@ -1,3 +1,4 @@
 export * from './localStorage';
 export * from './sessionStorage';
 export * from './webStorage';
+export * from './webStorageConfig';

--- a/lib/decorators/webStorageConfig.ts
+++ b/lib/decorators/webStorageConfig.ts
@@ -1,0 +1,11 @@
+import { IWebstorageConfig } from '../../dist/interfaces/config';
+import { KeyStorageHelper } from '../helpers/keyStorage';
+
+export function WebStorageConfig(config: IWebstorageConfig) {
+
+	return function(targetedClass:Object, raw:string) {
+		KeyStorageHelper.setCaseSensitivity(config.caseSensitive);
+		KeyStorageHelper.setStorageKeyPrefix(config.prefix);
+		KeyStorageHelper.setStorageKeySeparator(config.separator);
+	};
+};


### PR DESCRIPTION
Fix for https://github.com/PillowPillow/ng2-webstorage/issues/55.

Problem is that ngModule.forRoot method is executed only after all decorators are initialized. 
Which means, that default configuration will be used first and custom one will be applied only after any decorated value is changed.

This will lead to duplicated entries in both localStorage and sessionStorage.

Please let me know if this fix is acceptable, so I can adjust README as well.
 