### PR TITLE
[Ivy] Add Injectable decorators to fix Angular compilation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tsickle": "^0.35.0",
     "tslib": "^1.9.0",
     "tslint": "~5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.4.5"
   },
   "repository": {
     "type": "git",

--- a/projects/ngx-webstorage/package.json
+++ b/projects/ngx-webstorage/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-webstorage",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"peerDependencies": {
 		"@angular/common": "^8.0.0",
 		"@angular/core": "^8.0.0"

--- a/projects/ngx-webstorage/src/lib/strategies/inMemory.ts
+++ b/projects/ngx-webstorage/src/lib/strategies/inMemory.ts
@@ -2,8 +2,9 @@ import {StorageStrategy} from '../core/interfaces/storageStrategy';
 import {Observable, of, Subject} from 'rxjs';
 import {StrategyCacheService} from '../core/strategyCache';
 import {StorageStrategies} from '../constants/strategy';
-import {Inject} from '@angular/core';
+import {Inject, Injectable} from '@angular/core';
 
+@Injectable()
 export class InMemoryStorageStrategy implements StorageStrategy<any> {
 	static readonly strategyName: string = StorageStrategies.InMemory;
 	readonly keyChanges: Subject<string> = new Subject();

--- a/projects/ngx-webstorage/src/lib/strategies/localStorage.ts
+++ b/projects/ngx-webstorage/src/lib/strategies/localStorage.ts
@@ -1,11 +1,12 @@
 import {StrategyCacheService} from '../core/strategyCache';
 import {BaseSyncStorageStrategy} from './baseSyncStorage';
-import {Inject, NgZone, PLATFORM_ID} from '@angular/core';
+import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
 import {LOCAL_STORAGE} from '../core/nativeStorage';
 import {StorageStrategies} from '../constants/strategy';
 import {isPlatformBrowser} from '@angular/common';
 import {WebStorage} from '../core/interfaces/webStorage';
 
+@Injectable()
 export class LocalStorageStrategy extends BaseSyncStorageStrategy {
 	static readonly strategyName: string = StorageStrategies.Local;
 	readonly name: string = LocalStorageStrategy.strategyName;

--- a/projects/ngx-webstorage/src/lib/strategies/sessionStorage.ts
+++ b/projects/ngx-webstorage/src/lib/strategies/sessionStorage.ts
@@ -1,11 +1,12 @@
 import {StrategyCacheService} from '../core/strategyCache';
 import {BaseSyncStorageStrategy} from './baseSyncStorage';
-import {Inject, NgZone, PLATFORM_ID} from '@angular/core';
+import {Inject, Injectable, NgZone, PLATFORM_ID} from '@angular/core';
 import {SESSION_STORAGE} from '../core/nativeStorage';
 import {StorageStrategies} from '../constants/strategy';
 import {isPlatformBrowser} from '@angular/common';
 import {WebStorage} from '../core/interfaces/webStorage';
 
+@Injectable()
 export class SessionStorageStrategy extends BaseSyncStorageStrategy {
 	static readonly strategyName: string = StorageStrategies.Session;
 	readonly name: string = SessionStorageStrategy.strategyName;


### PR DESCRIPTION
Redresses the following runtime error when compiling with Angular Ivy enabled.

```
Error: Can't resolve all parameters for InMemoryStorageStrategy: (?).
```

This is also a longstanding Angular dependency injection best practice. See:

- <https://angular.io/api/core/Injectable>
- <https://angular.io/guide/dependency-injection>

----

Also locks in TypeScript 3.4.5, since more recent versions are incompatible with Angular.

```
$ ng build ngx-webstorage
Building Angular Package
Building entry point 'ngx-webstorage'
Compiling TypeScript sources through ngc

BUILD ERROR
The Angular Compiler requires TypeScript >=3.4.0 and <3.5.0 but 3.5.3 was found instead.
An unhandled exception occurred: The Angular Compiler requires TypeScript >=3.4.0 and <3.5.0 but 3.5.3 was found instead.
error Command failed with exit code 127.
```