### PR TITLE
feat(provider): add a new provider function alongside its feature functions, to match angular v15+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8295,17 +8295,17 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8342,34 +8342,10 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -8419,21 +8395,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/express/node_modules/send": {
       "version": "0.18.0",
@@ -8757,9 +8718,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true,
       "funding": [
         {
@@ -9797,9 +9758,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "node_modules/ipaddr.js": {
@@ -10113,9 +10074,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -10826,9 +10787,9 @@
       }
     },
     "node_modules/karma-coverage-istanbul-reporter/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -11052,9 +11013,9 @@
       }
     },
     "node_modules/less/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -11389,9 +11350,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -15463,9 +15424,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -16941,9 +16902,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",
@@ -23162,17 +23123,17 @@
       "dev": true
     },
     "express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -23206,30 +23167,10 @@
           "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
           "dev": true
         },
-        "body-parser": {
-          "version": "1.20.1",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.1.2",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "2.0.0",
-            "destroy": "1.2.0",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "on-finished": "2.4.1",
-            "qs": "6.11.0",
-            "raw-body": "2.5.1",
-            "type-is": "~1.6.18",
-            "unpipe": "1.0.0"
-          }
-        },
         "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+          "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
           "dev": true
         },
         "debug": {
@@ -23267,18 +23208,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
-        },
-        "raw-body": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-          "dev": true,
-          "requires": {
-            "bytes": "3.1.2",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
         },
         "send": {
           "version": "0.18.0",
@@ -23552,9 +23481,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
     "foreground-child": {
@@ -24315,9 +24244,9 @@
       }
     },
     "ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
     "ipaddr.js": {
@@ -24543,9 +24472,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -25153,9 +25082,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "source-map": {
@@ -25260,9 +25189,9 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true,
           "optional": true
         },
@@ -25524,9 +25453,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -28617,9 +28546,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -29594,9 +29523,9 @@
           "dev": true
         },
         "webpack-dev-middleware": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-          "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+          "version": "5.3.4",
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+          "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
           "dev": true,
           "requires": {
             "colorette": "^2.0.10",

--- a/projects/ngx-webstorage/README.md
+++ b/projects/ngx-webstorage/README.md
@@ -7,6 +7,7 @@ It provides also two decorators to synchronize the component attributes and the 
 
 #### Index:
 * [Getting Started](#gstart)
+    * [Provider Function](#provider_fn)
 * [Services](#services):
 	* [LocalStorageService](#s_localstorage)
 	* [SessionStorageService](#s_sessionstorage)
@@ -92,6 +93,31 @@ It provides also two decorators to synchronize the component attributes and the 
 
 	}
 	```
+
+### <a name="provider_fn">Provider Function</a>
+
+Since the new standalone API and angular v15+, provider functions are now the way to go to configure your application ([learn more](https://angular.dev/reference/migrations/standalone)).
+
+1. From now on to setup your project, you can use the `provideNgxWebstorage` function.
+
+2. You can independently add the (you can of course add them both together):
+   - `localStorage` features with `withLocalStorage`
+   - `sessionStorage` features with `withLocalStorage`
+
+3. You can add a custom configuration with `withNgxWebstorageConfig`
+   
+```ts
+bootstrapApplication(AppComponent, {
+	providers: [
+		// ...
+		provideNgxWebstorage(
+			withNgxWebstorageConfig({ separator: ':', caseSensitive: true }),
+			withLocalStorage(),
+			withSessionStorage()
+		)
+	]
+})
+```
 
 ### <a name="services">Services</a>
 --------------------

--- a/projects/ngx-webstorage/src/lib/provider.spec.ts
+++ b/projects/ngx-webstorage/src/lib/provider.spec.ts
@@ -1,0 +1,79 @@
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {StrategyIndex} from './services/strategyIndex';
+import {STORAGE_STRATEGIES} from './strategies';
+import {StorageStrategy} from './core/interfaces/storageStrategy';
+import {StorageStrategyStub} from '../stubs/storageStrategy.stub';
+import {LocalStorageStrategy} from './strategies/localStorage';
+import {Component} from '@angular/core';
+import {LocalStorage} from './decorators';
+import {StorageKeyManager} from './helpers/storageKeyManager';
+import { provideNgxWebstorage, withLocalStorage, withNgxWebstorageConfig } from './provider';
+import { DefaultIsCaseSensitive, DefaultPrefix, DefaultSeparator } from './constants/config';
+
+describe('Provider', () => {
+
+	let strategyStub: StorageStrategy<any>;
+
+	@Component({selector: 'lib-mock', template: ''})
+	class LocalMockComponent {
+		@LocalStorage() prop: string;
+	}
+
+	let testFixture: ComponentFixture<LocalMockComponent>;
+	let testComponent: LocalMockComponent;
+
+	beforeEach(() => {
+		StorageKeyManager.setPrefix(DefaultPrefix);
+		StorageKeyManager.setSeparator(DefaultSeparator);
+		StorageKeyManager.setCaseSensitive(DefaultIsCaseSensitive);
+
+		strategyStub = new StorageStrategyStub(LocalStorageStrategy.strategyName);
+
+		TestBed.configureTestingModule({
+			providers: [
+				provideNgxWebstorage(withNgxWebstorageConfig({ prefix: 'new_prefix' }), withLocalStorage()),
+				{provide: STORAGE_STRATEGIES, useFactory: () => strategyStub, multi: true},
+			],
+			declarations: [
+				LocalMockComponent,
+			],
+		}).compileComponents();
+		testFixture = TestBed.createComponent(LocalMockComponent);
+		testComponent = testFixture.debugElement.componentInstance;
+	});
+
+	// The StrategyIndexer will skip indexing at the next beforeEach call if you dont clear the index
+	afterEach(() => StrategyIndex.clear());
+
+	it('should update the configuration prefix only', () => {
+		expect(StorageKeyManager.prefix).toEqual('new_prefix');
+		expect(StorageKeyManager.separator).toEqual(DefaultSeparator);
+		expect(StorageKeyManager.isCaseSensitive).toEqual(DefaultIsCaseSensitive);
+	})
+
+	it('should index the storage strategies', inject([], () => {
+		expect(StrategyIndex.hasRegistredStrategies()).toBeTruthy();
+	}));
+
+	it('should override the local strategy', inject([StrategyIndex], (index: StrategyIndex) => {
+		const strategy = index.getStrategy(LocalStorageStrategy.strategyName);
+		expect(strategy).toEqual(strategyStub);
+	}));
+
+	it('should access to the stub storage strategy by using decorators',
+		/*The inject isn't mandatory here, it's just for example*/
+		inject([StrategyIndex], (index: StrategyIndex) => {
+			const strategy: StorageStrategyStub = strategyStub as StorageStrategyStub;
+			// same than  const strategy: StorageStrategyStub = StorageStrategy.get(LocalStorageStrategy.strategyName) as StorageStrategyStub;
+			// or  const strategy: StorageStrategyStub = index.getStrategy(LocalStorageStrategy.strategyName) as StorageStrategyStub;
+
+			const propName: string = StorageKeyManager.normalize('prop');
+			expect(strategy.store[propName]).toBeUndefined();
+			testComponent.prop = 'foobar';
+
+			expect(testComponent.prop).toEqual('foobar');
+			expect(strategy.store[propName]).toEqual('foobar');
+		})
+	);
+});
+

--- a/projects/ngx-webstorage/src/lib/provider.ts
+++ b/projects/ngx-webstorage/src/lib/provider.ts
@@ -1,0 +1,92 @@
+import {APP_INITIALIZER,inject,makeEnvironmentProviders,Provider} from "@angular/core";
+import {NgxWebstorageConfiguration} from "./config";
+import {LIB_CONFIG} from "./module";
+import {StrategyIndex} from "../public_api";
+import {InMemoryStorageStrategyProvider,LocalStorageStrategyProvider,SessionStorageStrategyProvider} from "./strategies";
+import {LocalStorageProvider,SessionStorageProvider} from "./core/nativeStorage";
+import {LocalStorageServiceProvider} from "./services/localStorage";
+import {SessionStorageServiceProvider} from "./services/sessionStorage";
+import {DefaultIsCaseSensitive, DefaultPrefix, DefaultSeparator} from "./constants/config";
+import {StorageKeyManager} from "./helpers/storageKeyManager";
+
+enum NgxWebstorageFeatureKind {
+	Config,
+	LocalStorage,
+	SessionStorage,
+}
+
+type NgxWebstorageFeature<FeatureKind extends NgxWebstorageFeatureKind> = {
+	kind: FeatureKind;
+	providers: Provider[];
+};
+
+function appInit() {
+	const config = inject(LIB_CONFIG);
+	const index = inject(StrategyIndex);
+	return () => {
+		StorageKeyManager.consumeConfiguration(config);
+		index.indexStrategies();
+	};
+}
+
+/**
+ * Provide ngx-webstorage basic features.
+ *
+ * - You can customise the configuration with the `withConfiguration` feature.
+ * - You can enable the `LocalStorage` features with the `withLocalStorage` feature.
+ * - You can enable the `SessionStorage` features with the `withSessionStorage` feature.
+ *
+ * @default config { prefix: 'ngx-webstorage', separator: '|', caseSensitive: false }
+ */
+export function provideNgxWebstorage(...features: NgxWebstorageFeature<NgxWebstorageFeatureKind>[]) {
+	const { configProvider, featureProviders } = parseFeatures(features);
+ 	return makeEnvironmentProviders([
+		configProvider,
+		InMemoryStorageStrategyProvider,
+		{ provide: APP_INITIALIZER, useFactory: appInit, multi: true },
+		...featureProviders,
+	]);
+}
+
+function parseFeatures(features: NgxWebstorageFeature<NgxWebstorageFeatureKind>[]) {
+	let configProvider: Provider;
+	const featureProviders: Provider[] = [];
+
+	for (const feature of features) {
+		if (feature.kind === NgxWebstorageFeatureKind.Config) configProvider = feature.providers[0];
+		else featureProviders.push(...feature.providers);
+	}
+
+	return {
+		configProvider: configProvider ?? {
+			provide: LIB_CONFIG,
+			useValue: { prefix: DefaultPrefix, separator: DefaultSeparator, caseSensitive: DefaultIsCaseSensitive }
+		},
+		featureProviders
+	};
+}
+
+function makeNgxWebstorageFeature<FeatureKind extends NgxWebstorageFeatureKind>(kind: FeatureKind, providers: Provider[]): NgxWebstorageFeature<FeatureKind> {
+	return { kind, providers };
+}
+
+export function withNgxWebstorageConfig(config: NgxWebstorageConfiguration) {
+	return makeNgxWebstorageFeature(NgxWebstorageFeatureKind.Config, [{ provide: LIB_CONFIG, useValue: config }]);
+}
+
+/** Provides everything necessary to use the `LocalStorage` features. */
+export function withLocalStorage() {
+	return makeNgxWebstorageFeature(NgxWebstorageFeatureKind.LocalStorage, [
+		LocalStorageProvider,
+		LocalStorageServiceProvider,
+		LocalStorageStrategyProvider,
+	]);
+}
+
+export function withSessionStorage() {
+	return makeNgxWebstorageFeature(NgxWebstorageFeatureKind.SessionStorage, [
+		SessionStorageProvider,
+		SessionStorageServiceProvider,
+		SessionStorageStrategyProvider,
+	]);
+}

--- a/projects/ngx-webstorage/src/lib/strategies/index.ts
+++ b/projects/ngx-webstorage/src/lib/strategies/index.ts
@@ -11,3 +11,5 @@ export const Strategies: Provider[] = [
 	{provide: STORAGE_STRATEGIES, useClass: LocalStorageStrategy, multi: true},
 	{provide: STORAGE_STRATEGIES, useClass: SessionStorageStrategy, multi: true},
 ];
+
+export const [InMemoryStorageStrategyProvider, LocalStorageStrategyProvider, SessionStorageStrategyProvider] = Strategies;

--- a/projects/ngx-webstorage/src/public_api.ts
+++ b/projects/ngx-webstorage/src/public_api.ts
@@ -25,6 +25,7 @@ export {SessionStorageService} from './lib/services/sessionStorage';
 export * from './lib/core/interfaces/storageStrategy';
 export * from './lib/decorators';
 export * from './lib/module';
+export * from './lib/provider';
 
 
 


### PR DESCRIPTION
In order to match the angular standalone api, I added a new `provideNgxWebstorage` function, alongside a `withNgxWebstorageConfiguration`, `withLocalStorage` and `withSessionStorage` feature functions.
It has been developped, following the angular code style on this kind of functions (like [`provideHttpClient`](https://github.com/angular/angular/blob/0a8c48e76ef25e5dcba2502dedc00c4f638095ee/packages/common/http/src/provider.ts#L107) for example).